### PR TITLE
Add mk-ca-bundle.pl to MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,5 +4,6 @@ Makefile.PL
 MANIFEST			This list of files
 README
 update-cacert-file
+mk-ca-bundle.pl
 t/locate-file.t
 Changes


### PR DESCRIPTION
update-cacert-file is included in the distribution. This is useful to update the CA certs ourself.
However, the script relies on mk-ca-bundle.pl that is missing from the distribution.
