### PR TITLE
Demonstrate that latest Mozilla::CA 20141217 doesn't play nicely with ipnpb.paypal.com

### DIFF
--- a/t/paypal-ipn.t
+++ b/t/paypal-ipn.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+# This test will fail under Mozilla::CA 20141217 and IO::Socket::SSL 2.012
+
+use IO::Socket::SSL;
+use Mozilla::CA;
+use Test::More;
+use Test::RequiresInternet ( 'ipnpb.paypal.com' => 443 );
+
+my $host = 'ipnpb.paypal.com';
+
+my $client = IO::Socket::SSL->new(
+    PeerHost        => "$host:443",
+    SSL_verify_mode => 0x02,
+    SSL_ca_file     => Mozilla::CA::SSL_ca_file(),
+) || fail( "Can't connect: $@" );
+
+if ( $client ) {
+    ok( $client->verify_hostname( $host, "http" ), 'hostname verified' );
+}
+diag( 'ssl_ca_file : ' . Mozilla::CA::SSL_ca_file() );
+done_testing();


### PR DESCRIPTION
I think this is connected to https://rt.cpan.org/Public/Bug/Display.html?id=101908  We upgraded to the latest version of Mozilla::CA today and immediately found that we were getting errors connecting to PayPal's IPN callback URL.  This test demonstrates the issue.  We've reverted to 20130114 in the meantime, which fixes the problem.

The purpose of this pull request is purely to demonstrate the problem.  Having said that, the test suite as it stands is pretty minimal and it might be helpful to add a few optional tests for some high traffic SSL sites that would catch this sort of thing before release.