### PR TITLE
mk-ca-bundle.pl options

### DIFF
--- a/update-cacert-file
+++ b/update-cacert-file
@@ -6,7 +6,7 @@ use warnings;
 my $CACERT_PEM_FILE = "lib/Mozilla/CA/cacert.pem";
 my $GIT_AUTHOR = 'Mozilla <mozilla@mozilla.org>';
 
-run ("./mk-ca-bundle.pl", $CACERT_PEM_FILE);
+run ("./mk-ca-bundle.pl", "-p", "ALL:ALL", $CACERT_PEM_FILE);
 
 system("git", "diff", "--exit-code", $CACERT_PEM_FILE) or exit;
 


### PR DESCRIPTION
mk-ca-bundle.pl in curl changed in commit may 8th to change trust defaults for inclusion in the generated bundle.

This was specifically noticed because the cert for Verisign known as "Class 3 Public Primary Certification Authority" was not included in the bundle because it is not a 'TRUSTED_DELEGATOR', but also unfortunately happens to be the top of the chain that runs AWS ssl certs for secure communication with their systems

TL;DR: the latest Mozilla::CA does not work with a subset of ssl certificates, this patch fixes the build chain to avoid the problem.