### PR TITLE
New tests for when __FILE__ is relative

### DIFF
--- a/t/no-path.t
+++ b/t/no-path.t
@@ -1,0 +1,16 @@
+#!perl
+
+# For coverage. SSL_ca_file includes a conditional branch if the
+# __FILE__ name is not absolute. This is not tested elsewhere
+# so this test file exists simply to follow that branch and complete
+# the code coverage.
+
+use strict;
+use Test qw(plan ok);
+plan tests => 3;
+
+use lib './blib/lib';
+ok(require Mozilla::CA);
+my $ca_file = Mozilla::CA::SSL_ca_file();
+ok($ca_file);
+ok(-f $ca_file);


### PR DESCRIPTION
In SSL_ca_file the branch to turn the relative path to the bundle file into an absolute one is not tested by default (neither on my system nor at [cpancover](http://cpancover.com/latest//Mozilla-CA-20160104/blib-lib-Mozilla-CA-pm.html#12)). This PR is a simple new test file to ensure that it is tested and thus complete the coverage.

I've been assigned this dist as part of the [CPAN PR Challenge](http://cpan-prc.org) and it seems to be in really good shape. Even most of the open RT tickets are either actually resolved or apparently unresolvable. So if there is anything in particular you would like me to take a look at this month do let me know. Other than this sort of housekeeping there's not much else I can see needs to be done.
